### PR TITLE
add Rust Cargo bin to $PATH only if it exists (fix #68)

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,2 +1,5 @@
-
-export PATH="$HOME/.cargo/bin:$PATH"
+# Rust
+# if Rust’s Cargo `bin` is a directory, then add it to the $PATH
+if [[ -d $HOME/.cargo/bin ]]; then
+  export PATH="$HOME/.cargo/bin:$PATH"
+fi

--- a/.zprofile
+++ b/.zprofile
@@ -1,1 +1,5 @@
-export PATH="$HOME/.cargo/bin:$PATH"
+#!/usr/bin/env zsh
+
+# Rust
+# add Rust’s Cargo `bin` to the $PATH if the directory exists
+[[ -d $HOME/.cargo/bin ]] && export PATH="$HOME/.cargo/bin:$PATH"


### PR DESCRIPTION
rationale: withhold `$HOME/.cargo/bin` from the `$PATH` when Rust, Cargo aren’t installed