### PR TITLE
replace `jsonlint` with `jsonlint-newline-fork`

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,17 +16,11 @@ jobs:
       - uses: actions/checkout@v2.3.3
       - name: Install linter
         run: |
-          sudo npm install jsonlint -g
+          sudo npm install jsonlint-newline-fork -g
       - name: Lint
         run: >
           find ./ -type f -name '*.json' -print -exec
-          jsonlint --in-place "{}" \;
-      - name: Newline
-        # https://unix.stackexchange.com/q/31947#comment938219_161853
-        run: >
-          for file in **/*.json; do
-            tail -n1 "$file" | read -r _ || echo >> "$file"
-          done
+          jsonlint --in-place --insert-final-newline "{}" \;
       - uses: peter-evans/create-pull-request@v3
         with:
           commit-message: "[autofix] Format JSON content"


### PR DESCRIPTION
ensure all JSON files close with a newline