### PR TITLE
call `jsonlint-newline-fork` instead of `jsonlint`

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Lint
         run: >
           find ./ -type f -name '*.json' -print -exec
-          jsonlint --in-place --insert-final-newline "{}" \;
+          jsonlint-newline-fork --in-place --insert-final-newline "{}" \;
       - uses: peter-evans/create-pull-request@v3
         with:
           commit-message: "[autofix] Format JSON content"


### PR DESCRIPTION
See if this makes a difference?