### PR TITLE
rm `docker` URI scheme

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -44,7 +44,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3.12.0
+        uses: github/super-linter@v3.12.0
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main


### PR DESCRIPTION
https://github.com/github/super-linter/commit/0744055595da9908dff217b26640f8db016ec764 shows that Super-Linter’s no longer using
`docker://github/super-linter:v3`, but now rather
`         github/super-linter@v3`
