### PR TITLE
make `wget` work on Alpine Linux and macOS

### DIFF
--- a/!=Mackup/CodeSnippets.md
+++ b/!=Mackup/CodeSnippets.md
@@ -443,8 +443,7 @@ if your example.csv has too many rows ([via](https://web.archive.org/web/2018121
 
 ## wget
 
-`wgetserver=`'**example.com**' `&& \`<br/>
-`wget --mirror --continue --verbose --append-output=$wgetserver.log --execute robots=off --restrict-file-names=nocontrol --timestamping --debug --recursive --show-progress http://$wgetserver && unset wgetserver || unset wgetserver`
+`wgetserver=`'**example.com**' `&& (wget --mirror --continue --verbose --append-output=$wgetserver.log --execute robots=off --restrict-file-names=nocontrol --timestamping --debug --recursive --show-progress http://$wgetserver || wget --continue  http://$wgetserver) && unset wgetserver || unset wgetserver`
 
 ## WiFi
 


### PR DESCRIPTION
- [x] if the macOS instructions fail, then try a simplified ⊆ of them