### PR TITLE
replace toml repository name programmatically

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -12,7 +12,7 @@ name = "go"
 enabled = true
 
   [analyzers.meta]
-  import_paths = ["github.com/LucasLarson/dotfiles"]
+  import_paths = ['github.com/LucasLarson/"$(git rev-parse --show-toplevel | xargs basename)"']
 
 [[analyzers]]
 name = "test-coverage"


### PR DESCRIPTION
can `.toml` files handle `"$(git rev-parse --show-toplevel | xargs basename)"`?