### PR TITLE
test replacing LucasLarson with `${{ github.repository_owner }}` in TOML file

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -12,7 +12,7 @@ name = "go"
 enabled = true
 
   [analyzers.meta]
-  import_paths = ['github.com/LucasLarson/"$(git rev-parse --show-toplevel | xargs basename)"']
+  import_paths = ['github.com/${{ github.repository_owner }}/"$(git rev-parse --show-toplevel | xargs basename)"']
 
 [[analyzers]]
 name = "test-coverage"


### PR DESCRIPTION
set more of the repository programmatically if possible (alternatively, this is not urgent because the `github.repository_owner` has never changed so far.