### PR TITLE
add scaffolding for `~/.zlogin`

### DIFF
--- a/.zlogout
+++ b/.zlogout
@@ -1,1 +1,0 @@
-#!/usr/bin/env zsh


### PR DESCRIPTION
scaffolding only for a file that is sourced upon shell opening