### PR TITLE
repair jsonlint workflow’s `find` syntax

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,16 +21,16 @@ jobs:
         run: |
           sudo npm install jsonlint-newline-fork -g
       - name: Lint
-        run: >
-          find -- * -type f \( \(
-              -iname '*.json' -or
-              -iname '*.imgbotconfig' -or
-              -iname '*.whitesource'
-            ) -and
-            -not -path '*node_modules*' -and
-            -not -path '*vscode*'
-          ) -print -exec
-          jsonlint --in-place --insert-final-newline {} \;
+        run: |
+          find -- * -type f \( \( \
+              -iname '*.json' -or \
+              -iname '*.imgbotconfig' -or \
+              -iname '*.whitesource' \
+            \) -and \
+            -not -path '*node_modules*' -and \
+            -not -path '*vscode*' \
+          \) -print -exec \
+          jsonlint --in-place --insert-final-newline -- {} \;
       - uses: peter-evans/create-pull-request@v3.8.0
         with:
           commit-message: "[autofix] Format JSON content"


### PR DESCRIPTION
error message

    find: invalid expression; expected to find
    a ')' but didn't see one.  Perhaps you need
    an extra predicate after '('