### PR TITLE
if there’s `/etc/motd`, clear its contents without newline (fix #262)

### DIFF
--- a/setup/linux/alpine/init.sh
+++ b/setup/linux/alpine/init.sh
@@ -136,7 +136,10 @@ command -v pip >/dev/null 2>&1 && (
 printf '\n\ncleaning up temporary installation files and housekeeping...\n'
 [ -e apk.static ] && rm apk.static
 [ -e get-pip.py ] && rm get-pip.py
-[ -e /etc/motd ] && printf '' >/etc/motd
+
+# message of the day
+[ -e /etc/motd.bak ] || cp /etc/motd /etc/motd.bak
+printf '' >/etc/motd
 
 # delete thumbnail cache files
 find -- . -type f \( \


### PR DESCRIPTION
a message of the day – or motd – is rarely helpful, especially @AlpineLinux’s