### PR TITLE
add notice that installing pip is slow (fix #261)

### DIFF
--- a/setup/linux/alpine/init.sh
+++ b/setup/linux/alpine/init.sh
@@ -89,7 +89,8 @@ command -v python >/dev/null 2>&1 || (
 
 # pip
 command -v pip >/dev/null 2>&1 || (
-  printf '\ninstalling pip...\n'
+  printf '\ninstalling pip...\n' && sleep 3
+  printf 'this may take a while...\n'
   curl http://web.archive.org/web/20201031072740id_/bootstrap.pypa.io/get-pip.py -o get-pip.py
   python3 get-pip.py
 )


### PR DESCRIPTION
if installing pip for the first time, alert the user that it’s not speedy (fix #261)