### PR TITLE
use `builtin cd` instead of `command cd` (fix #388)

### DIFF
--- a/setup/init.sh
+++ b/setup/init.sh
@@ -14,7 +14,7 @@ printf '  a Lucas Larson production\n\n'
 sleep 1
 
 # start from `$HOME`
-[ -n "${HOME}" ] && builtin cd || exit 1
+[ -n "${HOME}" ] && builtin cd -- "${HOME}" || exit 1
 
 # unset `$PS4`
 # if this quaternary prompt string is already unset, then


### PR DESCRIPTION
- [x] `cd`‘s a `builtin`
- [ ] ~`"${HOME}"`’s `cd`’s default~ this script is affirmatively avoiding ambiguities and defaults; `"${HOME}"` remains (2381224)
- [x] fix #388