### PR TITLE
replace `find -exec command` with `find -exec` (fix #392)

### DIFF
--- a/custom/aliases.zsh
+++ b/custom/aliases.zsh
@@ -580,7 +580,7 @@ find_shell_scripts() {
     command find -- . \
       ! -path '*.git/*' \
       -type f \
-      -exec command head -n1 {} \+ 2>/dev/null |
+      -exec head -n1 {} \+ 2>/dev/null |
       command grep \
         --binary-files=without-match \
         --exclude-dir='.git' \


### PR DESCRIPTION
- [x] replace `find -exec command head -n1` with `find -exec head -n1` for @AlpineLinux
- [x] fix #392
