### PR TITLE
use @Homebrew’s `env` variable for `brew --prefix` (fix #497)

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -197,97 +197,97 @@ export GPG_TTY="${TTY-}"
 if command -v brew >/dev/null 2>&1; then
 
   # https://github.com/driesvints/dotfiles/blob/388baf1/path.zsh#L17
-  BREW_PREFIX="$(command brew --prefix)"
-  test -d "${BREW_PREFIX-}/sbin" &&
-    PATH="${BREW_PREFIX-}/sbin${PATH:+:${PATH-}}"
+  HOMEBREW_PREFIX="$(command brew --prefix)"
+  test -d "${HOMEBREW_PREFIX-}/sbin" &&
+    PATH="${HOMEBREW_PREFIX-}/sbin${PATH:+:${PATH-}}"
 
   # GNU bc calculator
-  test -d "${BREW_PREFIX-}/opt/bc/bin" &&
-    PATH="${BREW_PREFIX-}/opt/bc/bin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/bc/share/man" &&
+  test -d "${HOMEBREW_PREFIX-}/opt/bc/bin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/bc/bin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/bc/share/man" &&
     # Homebrew `MANPATH`
     # https://github.com/ferrarimarco/dotfiles/blob/eb176e4/.path#L14-L20
-    MANPATH="${BREW_PREFIX-}/opt/bc/share/man${MANPATH:+:${MANPATH-}}"
+    MANPATH="${HOMEBREW_PREFIX-}/opt/bc/share/man${MANPATH:+:${MANPATH-}}"
 
   # curl
-  test -d "${BREW_PREFIX-}/opt/curl/bin" &&
-    PATH="${BREW_PREFIX-}/opt/curl/bin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/curl/share/man" &&
-    MANPATH="${BREW_PREFIX-}/opt/curl/share/man${MANPATH:+:${MANPATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/curl/bin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/curl/bin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/curl/share/man" &&
+    MANPATH="${HOMEBREW_PREFIX-}/opt/curl/share/man${MANPATH:+:${MANPATH-}}"
 
   # GNU coreutils
   # for `date`, `cat`, `ln`
   # https://apple.stackexchange.com/a/135749
-  test -d "${BREW_PREFIX-}/opt/coreutils/libexec/gnubin" &&
-    PATH="${BREW_PREFIX-}/opt/coreutils/libexec/gnubin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/coreutils/libexec/gnuman" &&
-    MANPATH="${BREW_PREFIX-}/opt/coreutils/libexec/gnuman${MANPATH:+:${MANPATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/coreutils/libexec/gnubin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/coreutils/libexec/gnubin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/coreutils/libexec/gnuman" &&
+    MANPATH="${HOMEBREW_PREFIX-}/opt/coreutils/libexec/gnuman${MANPATH:+:${MANPATH-}}"
 
   # GNU findutils
   # for `find`, `xargs`, `locate`
-  test -d "${BREW_PREFIX-}/opt/findutils/libexec/gnubin" &&
-    PATH="${BREW_PREFIX-}/opt/findutils/libexec/gnubin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/findutils/libexec/gnuman" &&
-    MANPATH="${BREW_PREFIX-}/opt/findutils/libexec/gnuman${MANPATH:+:${MANPATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/findutils/libexec/gnubin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/findutils/libexec/gnubin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/findutils/libexec/gnuman" &&
+    MANPATH="${HOMEBREW_PREFIX-}/opt/findutils/libexec/gnuman${MANPATH:+:${MANPATH-}}"
 
   # grep
   # use latest via Homebrew but without the `g` prefix
   # https://github.com/Homebrew/homebrew-core/blob/ba7a70f/Formula/grep.rb#L43-L46
-  test -d "${BREW_PREFIX-}/opt/grep/libexec/gnubin" &&
-    PATH="${BREW_PREFIX-}/opt/grep/libexec/gnubin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/grep/libexec/gnuman" &&
-    MANPATH="${BREW_PREFIX-}/opt/grep/libexec/gnuman${MANPATH:+:${MANPATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/grep/libexec/gnubin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/grep/libexec/gnubin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/grep/libexec/gnuman" &&
+    MANPATH="${HOMEBREW_PREFIX-}/opt/grep/libexec/gnuman${MANPATH:+:${MANPATH-}}"
 
   # libarchive
-  test -d "${BREW_PREFIX-}/opt/libarchive/bin" &&
-    PATH="${BREW_PREFIX-}/opt/libarchive/bin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/libarchive/share/man" &&
-    MANPATH="${BREW_PREFIX-}/opt/libarchive/share/man${MANPATH:+:${MANPATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/libarchive/bin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/libarchive/bin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/libarchive/share/man" &&
+    MANPATH="${HOMEBREW_PREFIX-}/opt/libarchive/share/man${MANPATH:+:${MANPATH-}}"
 
   # make
   # use latest via Homebrew but without the `g` prefix
   # https://github.com/Homebrew/homebrew-core/blob/9591758/Formula/make.rb#L37-L41
-  test -d "${BREW_PREFIX-}/opt/make/libexec/gnubin" &&
-    PATH="${BREW_PREFIX-}/opt/make/libexec/gnubin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/make/libexec/gnuman" &&
-    MANPATH="${BREW_PREFIX-}/opt/make/libexec/gnuman${MANPATH:+:${MANPATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/make/libexec/gnubin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/make/libexec/gnubin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/make/libexec/gnuman" &&
+    MANPATH="${HOMEBREW_PREFIX-}/opt/make/libexec/gnuman${MANPATH:+:${MANPATH-}}"
 
   # openssl
-  test -d "${BREW_PREFIX-}/opt/openssl/bin" &&
-    PATH="${BREW_PREFIX-}/opt/openssl/bin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/openssl/share/man" &&
-    MANPATH="${BREW_PREFIX-}/opt/openssl/share/man${MANPATH:+:${MANPATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/openssl/bin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/openssl/bin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/openssl/share/man" &&
+    MANPATH="${HOMEBREW_PREFIX-}/opt/openssl/share/man${MANPATH:+:${MANPATH-}}"
   # `$LDFLAGS`, `$CPPFLAGS` are space-delimited
   # https://thelinuxcluster.com/2018/11/13/using-multiple-ldflags-and-cppflags
   # skip adding initial and terminal spaces
   # https://unix.stackexchange.com/a/162893
-  export LDFLAGS="${LDFLAGS:+${LDFLAGS-} }-L${BREW_PREFIX-}/opt/openssl/lib"
-  export CPPFLAGS="${CPPFLAGS:+${CPPFLAGS-} }-I${BREW_PREFIX-}/opt/openssl/include"
+  export LDFLAGS="${LDFLAGS:+${LDFLAGS-} }-L${HOMEBREW_PREFIX-}/opt/openssl/lib"
+  export CPPFLAGS="${CPPFLAGS:+${CPPFLAGS-} }-I${HOMEBREW_PREFIX-}/opt/openssl/include"
 
   # PKG_CONFIG_PATH is colon-delimited
   # https://superuser.com/a/1277306
-  PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH-}:}${BREW_PREFIX-}/opt/openssl/lib/pkgconfig"
+  PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH-}:}${HOMEBREW_PREFIX-}/opt/openssl/lib/pkgconfig"
 
   # sed
   # https://github.com/Homebrew/homebrew-core/blob/8ec6f0e/Formula/gnu-sed.rb#L35-L39
-  test -d "${BREW_PREFIX-}/opt/gnu-sed/libexec/gnubin" &&
-    PATH="${BREW_PREFIX-}/opt/gnu-sed/libexec/gnubin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/gnu-sed/libexec/gnuman" &&
-    MANPATH="${BREW_PREFIX-}/opt/gnu-sed/libexec/gnuman${MANPATH:+:${MANPATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/gnu-sed/libexec/gnubin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/gnu-sed/libexec/gnubin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/gnu-sed/libexec/gnuman" &&
+    MANPATH="${HOMEBREW_PREFIX-}/opt/gnu-sed/libexec/gnuman${MANPATH:+:${MANPATH-}}"
 
   # texinfo for `info`
   # “more detailed than . . . manpage (as is true for most GNU utilities)”
   # https://stackoverflow.com/a/1489405
-  test -d "${BREW_PREFIX-}/opt/texinfo/bin" &&
-    PATH="${BREW_PREFIX-}/opt/texinfo/bin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/texinfo/share/man" &&
-    MANPATH="${BREW_PREFIX-}/opt/texinfo/share/man${MANPATH:+:${MANPATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/texinfo/bin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/texinfo/bin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/texinfo/share/man" &&
+    MANPATH="${HOMEBREW_PREFIX-}/opt/texinfo/share/man${MANPATH:+:${MANPATH-}}"
 
   # which
-  test -d "${BREW_PREFIX-}/opt/gnu-which/libexec/gnubin" &&
-    PATH="${BREW_PREFIX-}/opt/gnu-which/libexec/gnubin${PATH:+:${PATH-}}"
-  test -d "${BREW_PREFIX-}/opt/gnu-which/libexec/gnuman" &&
-    MANPATH="${BREW_PREFIX-}/opt/gnu-which/libexec/gnuman${MANPATH:+:${MANPATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/gnu-which/libexec/gnubin" &&
+    PATH="${HOMEBREW_PREFIX-}/opt/gnu-which/libexec/gnubin${PATH:+:${PATH-}}"
+  test -d "${HOMEBREW_PREFIX-}/opt/gnu-which/libexec/gnuman" &&
+    MANPATH="${HOMEBREW_PREFIX-}/opt/gnu-which/libexec/gnuman${MANPATH:+:${MANPATH-}}"
 fi
 
 # Rust Cargo


### PR DESCRIPTION
0812e273ea replaced `/usr/local` with `$BREW_PREFIX`, generated here:
https://github.com/LucasLarson/dotfiles/blob/0812e273ea59b375c7099108bd6222f1c2c9cfe7/.zshrc#L171

Meanwhile at @Homebrew, there is a strong preference for `$HOMEBREW_PREFIX`:
| search results[^date] | query |
|----------------|----|
| 529 | ["HOMEBREW_PREFIX"](https://github.com/search?type=code&q=org%3AHomebrew+%22HOMEBREW_PREFIX%22) |
| 3 | ["BREW_PREFIX"](https://github.com/search?type=code&q=org%3AHomebrew+%22BREW_PREFIX%22) |

This repository should match theirs (fix #497).

[^date]: in @Homebrew’s repositories on 2022-03-08