### PR TITLE
remove `~/.zprofile`, `~/.zlogin` and `~/.zlogout`

### DIFF
--- a/.zlogin
+++ b/.zlogin
@@ -1,1 +1,0 @@
-#!/usr/bin/env sh

--- a/.zlogout
+++ b/.zlogout
@@ -1,1 +1,0 @@
-#!/usr/bin/env sh

--- a/.zprofile
+++ b/.zprofile
@@ -1,1 +1,0 @@
-#!/usr/bin/env sh


### PR DESCRIPTION
Removes files empty except for shell directive, files whose existence @romkatv’s `zsh4humans` implies[^1] is, at best, harmless.

[^1]: https://github.com/romkatv/zsh4humans/tree/88dad93cc4#additional-zsh-startup-files

Does not remove the identical[^2] `~/.profile` whose name `zsh4humans` doesn’t mention.

[^2]: https://github.com/LucasLarson/dotfiles/blob/df7a2615ce/.profile