### PR TITLE
remove `git.io` links (fix #519)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,6 @@
 ---
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://git.io/help-dependabot-configuration
-# https://github.com/dependabot/dependabot-core/issues/2219#issuecomment-829501674
 
 version: 2
 updates:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -6,11 +6,6 @@
 #########################
 name: Super-Linter
 
-#
-# Documentation:
-# https://git.io/workflow-syntax-for-github-actions
-#
-
 #############################
 # Start the job on all push #
 #############################

--- a/.zshrc
+++ b/.zshrc
@@ -321,7 +321,6 @@ test -d "${NPM_PACKAGES-}/share/man" &&
   MANPATH="${MANPATH:+${MANPATH-}:}${NPM_PACKAGES-}/share/man"
 
 # completion dots
-# https://git.io/completion-dots-in-.zshrc
 expand-or-complete-with-dots() {
   printf '\033[0;31m...\033[0m'
   zle expand-or-complete
@@ -360,7 +359,7 @@ setopt INTERACTIVE_COMMENTS
 # pyenv
 test -d "${HOME-}/.pyenv/shims" &&
   PATH="${HOME-}/.pyenv/shims${PATH:+:${PATH-}}"
-# https://git.io/init_-_--no-rehash
+# https://gist.github.com/4a4c4986ccdcaf47b91e8227f9868ded#prezto
 # https://github.com/caarlos0/carlosbecker.com/commit/c5f04d6
 pyenv() {
   eval "$(command pyenv init - --no-rehash "${SHELL##*[-./]}")"
@@ -401,7 +400,7 @@ test -d "${HOME-}/.local/bin" &&
 
 # rbenv
 # https://hackernoon.com/the-only-sane-way-to-setup-fastlane-on-a-mac-4a14cb8549c8#6a04
-# https://git.io/init_-_--no-rehash
+# https://gist.github.com/4a4c4986ccdcaf47b91e8227f9868ded#prezto
 # https://github.com/caarlos0/carlosbecker.com/commit/c5f04d6
 test -d "${HOME-}/.rbenv/shims" &&
   PATH="${HOME-}/.rbenv/shims${PATH:+:${PATH-}}"

--- a/custom/aliases.zsh
+++ b/custom/aliases.zsh
@@ -1393,7 +1393,7 @@ non_ascii() {
 }
 
 # paste faster
-# https://git.io/pasteinit-pastefinish
+# https://github.com/zsh-users/zsh-autosuggestions/issues/238#issuecomment-389324292
 pasteinit() {
   OLD_SELF_INSERT="${"${(s.:.)widgets[self-insert]}"[2,3]}"
   zle -N self-insert url-quote-magic


### PR DESCRIPTION
@GitHub ends 11 years of serving `git.io` redirections on 2022-04-29[^1] after providing 3 days warning. This pull request removes affected content to fix #519.

[^1]: [github.blog/changelog/2022-04-25-git-io-deprecation](https://github.blog/changelog/2022-04-25-git-io-deprecation/)