### PR TITLE
reduce duplicate `vim-script` content (fix #597)

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,7 +1,1 @@
-set list
-
-" https://vi.stackexchange.com/a/430
-set listchars=eol:⏎,tab:␉·,trail:␠,nbsp:⎵
-
-" https://stackoverflow.com/q/44376722#comment75754498_44376722
-set ignorecase
+.config/nvim/init.vim


### PR DESCRIPTION
Vim uses `~/.vimrc` according to @HiPhish[^1], whereas Neovim uses `$XDG_CONFIG_HOME/init.vim`

this repository:
- uses both, and
- contains almost-identical files[^2]

replacing `~/.vimrc` with a symlink to `$XDG_CONFIG_HOME`/init.vim` will fix #597

---
[^1]: [reddit.com/comments/vp78ug](https://old.reddit.com/comments/vp78ug/_/iehk8bp)
[^2]: [LucasLarson/dotfiles/search (language: vim-script)](https://web.archive.org/web/20220823155640/https://github.com/LucasLarson/dotfiles/search?l=vim-script) as of 2022-08-23