### PR TITLE
add zsh-autosuggestions for command-line completions (#612)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule ".config/nvim/pack/github/start/copilot.vim"]
   path = .config/nvim/pack/github/start/copilot.vim
   url = https://github.com/github/copilot.vim
+[submodule "custom/plugins/zsh-autosuggestions"]
+  path = custom/plugins/zsh-autosuggestions
+  url = https://github.com/zsh-users/zsh-autosuggestions

--- a/.zshrc
+++ b/.zshrc
@@ -58,6 +58,7 @@ plugins+=(
   git-open
   zsh-abbr
   zsh-diff-so-fancy
+  zsh-autosuggestions
 )
 
 # plugin: zsh_codex


### PR DESCRIPTION
Add autosuggestions [like fish provides](https://web.archive.org/web/20221002170359id_/fishshell.com/docs/3.5/interactive#autosuggestions) which are [sort of available](https://unix.stackexchange.com/a/99306) for Z shell via [`zsh‑users/zsh‑autosuggestions`](https://github.com/zsh-users/zsh-autosuggestions) [`v0.7.0`](https://github.com/zsh-users/zsh-autosuggestions/tree/v0.7.0) ([`a411ef3e09`](https://github.com/zsh-users/zsh-autosuggestions/commit/a411ef3e09)) to fix #612.