### PR TITLE
serve unescaped pathnames to humans (#624)

### DIFF
--- a/custom/aliases.zsh
+++ b/custom/aliases.zsh
@@ -842,7 +842,7 @@ g() {
 }
 alias g.='command git status .'
 guo() {
-  command git -c color.status=always status --untracked-files=no |
+  command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
     command sed -e '$d'
 }
 
@@ -879,7 +879,7 @@ git_add() {
     command git add --verbose "${@:-.}"
     ;;
   esac &&
-    command git -c color.status=always status --untracked-files=no |
+    command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
     command sed -e '$d'
 }
 alias ga='git_add'
@@ -959,7 +959,7 @@ git_commit() {
     command git commit --signoff --verbose -m "$@" ||
       return 1
   fi
-  command git -c color.status=always status --untracked-files=no |
+  command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
     command sed -e '$d'
 }
 alias gc='git_commit'
@@ -1008,7 +1008,7 @@ gdom() {
 alias gf='git fetch --keep --multiple --progress --prune --verbose'
 gfgs() {
   command git fetch --all --prune --verbose &&
-    command git -c color.status=always status --untracked-files=no |
+    command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
     command sed -e '$d'
 }
 
@@ -1049,7 +1049,7 @@ git_garbage_collection() {
       GIT_TRACE='1' GIT_TRACE_PACK_ACCESS='1' GIT_TRACE_PACKET='1' GIT_TRACE_PERFORMANCE='1' GIT_TRACE_SETUP='1' command git maintenance start
     GIT_TRACE='1' GIT_TRACE_PACK_ACCESS='1' GIT_TRACE_PACKET='1' GIT_TRACE_PERFORMANCE='1' GIT_TRACE_SETUP='1' command git gc --aggressive --prune=now
     GIT_TRACE='1' GIT_TRACE_PACK_ACCESS='1' GIT_TRACE_PACKET='1' GIT_TRACE_PERFORMANCE='1' GIT_TRACE_SETUP='1' command git repack -a -d -f -F --window=4095 --depth=4095
-    GIT_TRACE='1' GIT_TRACE_PACK_ACCESS='1' GIT_TRACE_PACKET='1' GIT_TRACE_PERFORMANCE='1' GIT_TRACE_SETUP='1' command git -c color.status=always status --untracked-files=no |
+    GIT_TRACE='1' GIT_TRACE_PACK_ACCESS='1' GIT_TRACE_PACKET='1' GIT_TRACE_PERFORMANCE='1' GIT_TRACE_SETUP='1' command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
       command sed -e '$d'
   else
     return 1
@@ -1119,7 +1119,7 @@ git_move() {
       command mv -i "$@" ||
       return 1
   } &&
-    command git -c color.status=always status --untracked-files=no |
+    command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
     command sed -e '$d'
 }
 alias gmv='git_move'
@@ -1134,7 +1134,7 @@ git_pull() {
     command git rebase --abort
     command git rebase --strategy-option=theirs
   }
-  command git -c color.status=always status --untracked-files=no |
+  command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
     command sed -e '$d'
 }
 alias gp='git_pull'
@@ -1155,7 +1155,7 @@ alias git-default-origin='gdr'
 # git push
 git_push() {
   command git push --verbose --progress origin "$(command git symbolic-ref --quiet --short HEAD -- 2>/dev/null)" &&
-    command git -c color.status=always status --untracked-files=no |
+    command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
     command sed -e '$d'
 }
 alias gps='git_push'
@@ -1227,7 +1227,7 @@ alias gs='command git status'
 git_submodule_update() {
   command git submodule update --init --remote "$@" &&
     command git submodule sync "$@" &&
-    command git -c color.status=always status --untracked-files=no |
+    command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
     command sed -e '$d'
 }
 alias gsu='git_submodule_update'
@@ -1258,7 +1258,7 @@ git_update() {
       ;;
     esac
     command git submodule sync --recursive "$@"
-    command git -c color.status=always status --untracked-files=no |
+    command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
       command sed -e '$d'
   fi
 }
@@ -1420,7 +1420,7 @@ mu() {
     command mackup backup --force --root
     command git fetch --all --prune
     command git submodule update --init
-    command git -c color.status=always status --untracked-files=no |
+    command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
       command sed -e '$d'
     ;;
   *)
@@ -1428,7 +1428,7 @@ mu() {
     command git fetch --all --prune --verbose
     command git submodule update --init --recursive
     command git submodule sync --recursive
-    command git -c color.status=always status --untracked-files=no |
+    command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
       command sed -e '$d'
     ;;
   esac
@@ -1701,7 +1701,7 @@ zero() {
 
 ohmyzsh() {
   cd -- "${ZSH-}" &&
-    command git -c color.status=always status --untracked-files=no |
+    command git -c color.status=always -c core.quotePath=false status --untracked-files=no |
     command sed -e '$d'
 }
 alias zshenv='command "${EDITOR-}" -- "${HOME-}/.${SHELL##*[-./]}env"; . "${HOME-}/.${SHELL##*[-./]}rc" && exec -l -- "${SHELL##*[-./]}"'


### PR DESCRIPTION
- [x] add `-c quotePath=false` where git command to target audience-human output instead of `git status where scripting is not possible or is unlikely

Where `git config` allows for scope-wide preference for escaping “unusual[ly]”¹ named paths,² the same functionality is available on a per-invocation level,³ which allows for temporary syntactic sugar without blindingly blunted defaults (the default behavior is to escape and quote such content, which is the safest and most reasonable default, especially in situations where a machine or other third party might parse the output).

To that end, in the instances where this repository calls the function-scope `-c color.status=always`, it should call 𝑎𝑙𝑠𝑜 for unescaped pathnames with `-c core.quotePath=false`.

Merging this pull request will fix #624.

---
1. scare quotes in original⁴
2. `git config core.quotePath=false`
3. `git -c core.quotePath=false status`, for example, instead of `git status`
4. https://github.com/git/git/commit/9378c16135
