### PR TITLE
dynamically find `git add --patch` (#640)

### DIFF
--- a/setup/init.sh
+++ b/setup/init.sh
@@ -157,7 +157,7 @@ command -v -- git >/dev/null 2>&1 || {
 }
 
 # git add --patch
-test -x '/usr/libexec/git-core/git-add--interactive' || {
+test -x "$(command git --exec-path)"'/git-add--interactive' || {
   # https://stackoverflow.com/a/57632778
   install git-perl
 }


### PR DESCRIPTION
Verifying `git add -p`’s installation¹ will dynamically find `$GIT_EXEC_PATH`² to fix #640.

---
1. a Perl file named `git-add--interactive`³
2. [LucasLarson/dotfiles@`f978f2fa3f`/setup/init.sh § L160](https://github.com/LucasLarson/dotfiles/blob/f978f2fa3f/setup/init.sh#L160)
3. [git/git@`fc8a8126df`/git-add--interactive.perl](https://github.com/git/git/blob/fc8a8126df/git-add--interactive.perl)