### PR TITLE
restore `alias` definition portability (#641)

### DIFF
--- a/custom/aliases.zsh
+++ b/custom/aliases.zsh
@@ -98,8 +98,7 @@ brewfile() {
 command -v -- bat >/dev/null 2>&1 &&
   alias cat='command bat --decorations never'
 
-alias -- -='cd -'
-alias -- 1='cd -1'
+alias -- 1='cd -1' -='cd -'
 alias -- 2='cd -2'
 alias -- 3='cd -3'
 alias -- 4='cd -4'

--- a/custom/aliases.zsh
+++ b/custom/aliases.zsh
@@ -98,13 +98,13 @@ brewfile() {
 command -v -- bat >/dev/null 2>&1 &&
   alias cat='command bat --decorations never'
 
-alias -- 1='cd -1' -='cd -'
-alias -- 2='cd -2'
-alias -- 3='cd -3'
-alias -- 4='cd -4'
-alias -- ...='cd ../..'
-alias -- ....='cd ../../..'
-alias -- .....='cd ../../../..'
+alias 1='cd -1' -='cd -'
+alias 2='cd -2'
+alias 3='cd -3'
+alias 4='cd -4'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+alias .....='cd ../../../..'
 
 cdp() {
   cd_from="$(command pwd -L)"


### PR DESCRIPTION
- [x] hide `-`-initial alias from Zsh and
- [x] remove end-of-options delimiter from `alias` for Busybox on Alpine Linux in order to

fix #641.