### PR TITLE
use portable, POSIX-compliant sed (#656)

### DIFF
--- a/CodeSnippets.md
+++ b/CodeSnippets.md
@@ -426,12 +426,12 @@ Visual Studio Code<br>
 
 ### replace
 
-recursively replace each file’s first instance of `bin/bash`, `bin/sh`, or
-`bin/ash` with `usr/bin/env zsh` ([via](https://stackoverflow.com/a/11458836))
+recursively replace each file’s first instance of `/bin/bash`, `/bin/sh`, or
+`/bin/ash` with `/usr/bin/env zsh` ([via](https://stackoverflow.com/a/11458836))
 
 ```shell
-find -- . -type f -exec sed -E -i \
-  -e '/\/bin\/b?a?sh/{' \
+find -- . -type f -exec sed \
+  -e '/\/bin\/b\{0,1\}a\{0,1\}sh$/ {' \
   -e 's//\/usr\/bin\/env zsh/' \
   -e ':a' \
   -e '$! N' \

--- a/setup/init.sh
+++ b/setup/init.sh
@@ -339,9 +339,7 @@ command find -- . -type d -empty \
 command -v -- zsh >/dev/null 2>&1 &&
   command grep -E -e '/bin/b?a?sh' '/etc/passwd' 2>&1 &&
   cp -- '/etc/passwd' '/etc/passwd-'"${now-}" &&
-  # `-E` for extended regex searching for `/bin/ash` and `/bin/sh`
-  # `-i` for in-place editing
-  command sed -E -i -e "s|/bin/b?a?sh$|$(command -v -- zsh)|" '/etc/passwd'
+  command sed -e 's|/bin/b\{0,1\}a\{0,1\}sh$|'"$(command -v -- zsh)"'|' '/etc/passwd'
 
 # done
 { set +euvx; } 2>/dev/null


### PR DESCRIPTION
changing the default shell with `sed` instead of `sed -E -i` is:

- [x] portable, and it is
- [x] POSIX-compliant and does
- [x] ~not~ account for distributions where the default shell is `dash` like Ubuntu and Debian, but that is fine, because while `/bin/dash` is run, it a symlink to `/bin/dash`, located at `/bin/sh`, which is called, and which this solution does replace
- [x] will fix #656