### PR TITLE
protect `$HISTFILE` from Korn shell (#686)

### DIFF
--- a/.kshrc
+++ b/.kshrc
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+export HISTFILE="${HOME-}"'/.ksh_history'


### PR DESCRIPTION
grant `ksh`, `ksh93` their own `$HISTFILE` so they cannot destroy other `$HISTFILE`s (fix #686)