### PR TITLE
add list of Node global packages

### DIFF
--- a/.package-list.json
+++ b/.package-list.json
@@ -1,0 +1,25 @@
+{
+  "name": "lib",
+  "dependencies": {
+    "@prantlf/jsonlint": {
+      "version": "11.7.0",
+      "overridden": false
+    },
+    "markdownlint-cli": {
+      "version": "0.33.0",
+      "overridden": false
+    },
+    "npm": {
+      "version": "9.4.0",
+      "overridden": false
+    },
+    "standard": {
+      "version": "17.0.0",
+      "overridden": false
+    },
+    "trash-cli": {
+      "version": "5.0.0",
+      "overridden": false
+    }
+  }
+}


### PR DESCRIPTION
add a file with the [output of `npm ls -g --json`](https://github.com/LucasLarson/update/commit/f651abb58a) to ease reinstallation and fix #690

<span title="Latin: confer">𝑐𝑓.</span> [`brew leaves`](https://github.com/paulirish/dotfiles/blob/06097405f3/setup-a-new-machine.sh#L18-L21) or `brew bundle dump`’s [`~/.Brewfile`](https://github.com/LucasLarson/dotfiles/blob/HEAD/.Brewfile?rgh-link-date=2023-01-27T19%3A21%3A33Z)