### PR TITLE
use `unset -v` instead of `unset` to clear variables

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -119,11 +119,11 @@ for file in "${ZSH_CUSTOM-}"/plugins/**/*.plugin.*sh; do
   . "${file-}" 2>/dev/null &&
     FPATH="${FPATH:+${FPATH-}:}${file%/*}"
 done
-unset -- file
+unset -v -- file
 for file in "${ZSH_CUSTOM-}"/*sh; do
   . "${file-}"
 done
-unset -- file
+unset -v -- file
 
 ## MANPATH
 # Linux

--- a/CodeSnippets.md
+++ b/CodeSnippets.md
@@ -463,7 +463,7 @@ if your example.csv has too many rows ([via](https://web.archive.org/web/2018121
 command "${utility-}" --level=0 --mirror --continue --verbose \
 --append-output=./"${wget_server-}".log --execute robots=off --restrict-file-names=nocontrol --timestamping --debug --recursive --progress=bar --no-check-certificate --random-wait \
 --referer=https://"${wget_server-}" --adjust-extension --page-requisites --convert-links --server-response \
-https://"${wget_server-}"; unset wget_server utility`
+https://"${wget_server-}"; unset -v -- wget_server utility`
 
 ## Wi-Fi
 
@@ -545,7 +545,7 @@ command mkdir -p -- "${HOME-}"'/Library/Developer/Xcode/UserData/IB Support' && 
 command mkdir -p -- "${HOME-}"'/Library/Caches/JetBrains' && command mv -- "${HOME-}"'/Library/Caches/JetBrains' "${HOME-}"'/.Trash/JetBrains-'"${trash_date-}" \
 command mkdir -p -- "${HOME-}"'/Library/Caches/org.carthage.CarthageKit/DerivedData' && command mv -- "${HOME-}"'/Library/Caches/org.carthage.CarthageKit/DerivedData' "${HOME-}"'/.Trash/Carthage-'"${trash_date-}" \
 command mkdir -p -- "${HOME-}"'/Library/Caches/Homebrew/downloads' && command mv -- "${HOME-}"'/Library/Caches/Homebrew/downloads' "${HOME-}"'/.Trash/Homebrew-'"${trash_date-}" \
-command -v -- brew >/dev/null 2>&1 && { command brew autoremove --verbose; command brew cleanup --prune=all --verbose; } { set +o xtrace; unset -- trash_developer; unset -- trash_date; } 2>/dev/null; printf '\n\n\360\237%s\232\256  data successfully trashed\n' "${trash_developer-}"
+command -v -- brew >/dev/null 2>&1 && { command brew autoremove --verbose; command brew cleanup --prune=all --verbose; } { set +o xtrace; unset -v -- trash_developer; unset -v -- trash_date; } 2>/dev/null; printf '\n\n\360\237%s\232\256  data successfully trashed\n' "${trash_developer-}"
 ```
 
 ## delete

--- a/custom/aliases.zsh
+++ b/custom/aliases.zsh
@@ -62,7 +62,7 @@ bash_pretty() {
       } >|"${file-}"'.sh'
     fi
   done
-  unset -- file
+  unset -v -- file
 }
 
 brewfile() {
@@ -130,8 +130,8 @@ cdp() {
     printf -- '\342\200\230%s\342\200\231\n' "${cd_from-}"
     return 1
   fi
-  unset -- cd_from
-  unset -- cd_to
+  unset -v -- cd_from
+  unset -v -- cd_to
 }
 
 # cheat
@@ -278,8 +278,8 @@ clang_format() {
 command clang-format -i --style '{IndentWidth: ${IndentWidth-}, ColumnLimit: ${ColumnLimit-}}' --verbose -- '{}' 2>&1
 " ';' |
     command sed -e 's/\[1\/1\]//'
-  unset -- IndentWidth
-  unset -- ColumnLimit
+  unset -v -- IndentWidth
+  unset -v -- ColumnLimit
   printf -- '\n'
   printf -- '\342\234\205  done\041\n'
 }
@@ -453,8 +453,8 @@ cy() {
       # -L to follow symbolic links
       command cp -R -L -- "${file-}" "${target-}"
   done
-  unset -- file
-  unset -- target
+  unset -v -- file
+  unset -v -- target
 }
 
 # number of files
@@ -594,7 +594,7 @@ define() {
       builtin functions -x 2 -- "${query-}"
     fi
   done
-  unset -- query
+  unset -v -- query
 }
 alias d='define'
 
@@ -619,7 +619,7 @@ domain_name_from_url() {
     printf -- '%s' "${url-}" &&
       printf -- '\n'
   done
-  unset -- url
+  unset -v -- url
 }
 
 du() {
@@ -653,7 +653,7 @@ filename_spaces_to_underscores() {
           command tr "${1:-[[:space:]]}" "${2:-_}"
       )"
     done
-  unset -- filename
+  unset -v -- filename
 }
 
 file_closes_with_newline() {
@@ -972,7 +972,7 @@ git_config_file_locations() {
           LC_ALL='C' command sort -u
       )"
   done
-  unset -- scope
+  unset -v -- scope
 }
 
 unalias -- 'gd' 2>/dev/null
@@ -1074,9 +1074,9 @@ git_commit_initial_commit() {
     command git add --verbose -- . &&
       command git commit --signoff --verbose --message="$(printf -- '\342\234\250\302\240 initial commit')"
   fi
-  unset -- git_time
-  unset -- GIT_AUTHOR_DATE
-  unset -- GIT_COMMITTER_DATE
+  unset -v -- git_time
+  unset -v -- GIT_AUTHOR_DATE
+  unset -v -- GIT_COMMITTER_DATE
 }
 alias gcic='git_commit_initial_commit'
 alias ginit='command git init && command git status'
@@ -1174,7 +1174,7 @@ git_restore() {
     command git checkout --progress -- "${file-}"
   done &&
     command git status
-  unset -- file
+  unset -v -- file
 }
 alias grs='git_restore'
 
@@ -1184,7 +1184,7 @@ git_search() {
     while IFS='' read -r commit; do
       command git grep --color=always --extended-regexp --ignore-case --line-number -e "$@" "${commit-}" --
     done
-  unset -- commit
+  unset -v -- commit
 }
 alias gsearch='git_search'
 
@@ -1200,9 +1200,9 @@ git_shallow() {
       command git clone --depth 1 --shallow-submodules "${submodule_url-}" "${submodule_path-}"
     done
   command git submodule update
-  unset -- submodule
-  unset -- submodule_path
-  unset -- submodule_url
+  unset -v -- submodule
+  unset -v -- submodule_path
+  unset -v -- submodule_url
 }
 
 alias gsh='command git show'
@@ -1303,9 +1303,9 @@ gravatar() {
   printf -- 'https://gravatar.com/avatar/%s?s=%d\n' "${email-}" "${size-}"
 
   # cleanup variables
-  unset -- email
-  unset -- size
-  unset -- utility
+  unset -v -- email
+  unset -v -- size
+  unset -v -- utility
 }
 
 hash_abbreviate() {
@@ -1332,8 +1332,8 @@ hash_abbreviate() {
       return 1
     fi
   done
-  unset -- hash
-  unset -- length
+  unset -v -- hash
+  unset -v -- length
 }
 alias h7='hash_abbreviate'
 
@@ -1355,7 +1355,7 @@ h1() {
   for file; do
     command sed -e '1q' "${file-}"
   done
-  unset -- file
+  unset -v -- file
 }
 
 history_stats() {
@@ -1475,7 +1475,7 @@ command -v -- ocrmypdf >/dev/null 2>&1 &&
         -- \
         "${file-}" "${file-}".ocr.pdf
     done
-    unset file
+    unset -v -- file
   }
 
 # open current directory if no argument is given
@@ -1539,8 +1539,8 @@ path_check() {
         printf -- 'not a directory: %s\n' "${directory-}"
       fi
     done
-  unset -- argument
-  unset -- directory
+  unset -v -- argument
+  unset -v -- directory
   {
     set +o xtrace
   } 2>/dev/null
@@ -1626,7 +1626,7 @@ rm() {
     command "${utility-}" "$@"
     ;;
   esac
-  unset -- utility
+  unset -v -- utility
 }
 alias rmo='rm --others'
 
@@ -1642,7 +1642,7 @@ take() {
       printf -- 'directory \342\200\230%s\342\200\231 exists...\n' "${directory-}"
     fi
   done
-  unset -- directory
+  unset -v -- directory
 
   # POSIX-compliant `${@:$#}`-style and `${@: -1}`-style string indexing (SC3057)
   # https://stackoverflow.com/a/1853993
@@ -1656,7 +1656,7 @@ take() {
     # it’s not a directory
     return 1
   fi
-  unset -- directory
+  unset -v -- directory
 }
 
 transfer() {

--- a/setup/init.sh
+++ b/setup/init.sh
@@ -45,7 +45,7 @@ now="$(command date -- '+%Y%m%d')"_"$(command awk -- 'BEGIN {srand(); print sran
 # set it to the POSIX default: `+ `
 # https://opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html
 ps4_temporary="${PS4:-+ }"
-unset -- PS4
+unset -v -- PS4
 set -o xtrace
 
 # pacman
@@ -350,7 +350,7 @@ printf -- 'exiting to apply updates...\n' 2>/dev/null
 
 # restore `$PS4`
 PS4="${ps4_temporary:-+ }"
-unset -- ps4_temporary
+unset -v -- ps4_temporary
 
 {
   printf -- '\n'


### PR DESCRIPTION
using `unset -v` instead of `unset` when unsetting variables will ensure better compatibility, portability, and maintainability:

- `unset -v` has been part of the POSIX specification for [at least a quarter century](https://web.archive.org/web/20220818022810id_/pubs.opengroup.org/onlinepubs/009639599/toc.pdf#page=106)¹ and
- using more specificity when intentionally destroying data is always a good thing
- will fix #697