### PR TITLE
prepend `cp` with `command` to avoid unexpected behavior

### DIFF
--- a/setup/init.sh
+++ b/setup/init.sh
@@ -280,7 +280,7 @@ set -o xtrace
 
 # message of the day
 test -w '/etc/motd' &&
-  cp -- '/etc/motd' '/etc/motd-'"${now-}" &&
+  command cp -- '/etc/motd' '/etc/motd-'"${now-}" &&
   printf -- '' >'/etc/motd'
 
 # delete thumbnail cache files
@@ -339,7 +339,7 @@ command find -- . -type d -empty \
 test -w '/etc/passwd' &&
   command -v -- zsh >/dev/null 2>&1 &&
   command grep -E -e '/bin/b?a?sh' '/etc/passwd' 2>&1 &&
-  cp -- '/etc/passwd' '/etc/passwd-'"${now-}" &&
+  command cp -- '/etc/passwd' '/etc/passwd-'"${now-}" &&
   command sed -e 's|/bin/b\{0,1\}a\{0,1\}sh$|'"$(command -v -- zsh)"'|' '/etc/passwd-'"${now-}" >'/etc/passwd'
 
 # done


### PR DESCRIPTION
correct the mistake in calling `cp` instead of `command cp` in [LucasLarson/dotfiles@`ee3c5bfd59`](https://github.com/LucasLarson/dotfiles/commit/ee3c5bfd594ccdc31dcf71f07c8ea107e4524401) to fix #699.

`cp` is super likely to be in an alias definition, which can [result in unexpected behavior](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/command.html#tag_20_22_16).