### PR TITLE
remove `git-perl` installation

### DIFF
--- a/setup/init.sh
+++ b/setup/init.sh
@@ -152,12 +152,6 @@ command -v -- git >/dev/null 2>&1 || {
   install git git-doc
 }
 
-# git add --patch
-test -x "$(command git --exec-path)"'/git-add--interactive' || {
-  # https://stackoverflow.com/a/57632778
-  install git-perl
-}
-
 # git user
 command git config --global --get user.name >/dev/null 2>&1 || {
   command git config --global user.name 'Lucas Larson'


### PR DESCRIPTION
Git v2.40.0 [removed the Perl version of `git add --interactive`](https://archive.today/2023.03.14-211437/https://wp.me/pamS32-iou#selection-1013.12-1015.21)

Moreover, `git-add--interactive`’s [installation by way of Alpine Linux’s `git-perl`](https://github.com/LucasLarson/dotfiles/blob/b49d5ca11b9e2a03951b62c4cdd4a1790a2b34a5/setup/init.sh#L155-L159) has been unnecessary since Git v2.25.0, released in January 2020; this fixes #722