### PR TITLE
remove zsh_codex plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,10 +26,6 @@
   branch = main
   path = custom/plugins/zsh-diff-so-fancy
   url = https://github.com/zdharma-continuum/zsh-diff-so-fancy
-[submodule "custom/plugins/zsh_codex"]
-  branch = main
-  path = custom/plugins/zsh_codex
-  url = https://github.com/tom-doerr/zsh_codex
 [submodule "custom/plugins/zsh-abbr"]
   branch = main
   path = custom/plugins/zsh-abbr

--- a/.zshrc
+++ b/.zshrc
@@ -60,17 +60,6 @@ plugins+=(
   zsh-autosuggestions
 )
 
-# plugin: zsh_codex
-test -r "${XDG_CONFIG_HOME-}"'/openaiapirc' || {
-  printf -- '[openai]\n'
-  printf -- 'organization_id = %s\n' "${OPENAI_ORGANIZATION_ID-}"
-  printf -- 'secret_key = %s\n' "${OPENAI_SECRET_KEY-}"
-} >|"${XDG_CONFIG_HOME-}"'/openaiapirc' &&
-  bindkey '^X' create_completion &&
-  plugins+=(
-    zsh_codex
-  )
-
 # plugin: fast-syntax-highlighting
 # performs best when loaded late, but before zsh-history-substring-search
 plugins+=(


### PR DESCRIPTION
remove the zsh_codex plugin which was used only to access OpenAI’s code completion. This will fix #732.