### PR TITLE
add `shellcheck` configuation

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,14 @@
+## .shellcheckrc
+# https://github.com/koalaman/shellcheck/blob/4e703e5c61/shellcheck.1.md#options
+
+# allow conforming shells besides sh, bash, ksh, dash
+disable=SC1071
+
+# allow linking to, but not following, linked scripts
+disable=SC1091
+
+# allow `$PATH` modification
+disable=SC2123
+
+# allow masking return values
+disable=SC2312


### PR DESCRIPTION
universally disable:
- [x] [SC1071](https://shellcheck.net/wiki/SC1071) (to allow conforming shells besides `sh`, `bash`, `ksh`, `dash`) 
- [x] [SC1091](https://shellcheck.net/wiki/SC1091) (to allow linking to, but not following, linked scripts)
- [x] [SC2123](https://shellcheck.net/wiki/SC2123) (to allow `$PATH` modification)
- [x] [SC2312](https://shellcheck.net/wiki/SC2312) (to allow masking return values)