### PR TITLE
add decimal time script

### DIFF
--- a/bin/dtime
+++ b/bin/dtime
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# decimal time according to the Calendrier républicain
+# https://web.archive.org/web/0id_/leahneukirchen.org/dotfiles/bin/fdate
+LC_ALL='C' command date -- '+%H %M %S' |
+  command awk -- '{
+  percentage = ($1 * 60 * 60 + $2 * 60 + $3) / (24 * 60 * 60)
+  printf "%d:%02d:%02d\n", substr(percentage, 3, 1), substr(percentage, 4, 2), substr(percentage, 6, 2)
+}'


### PR DESCRIPTION
This script is a reduced version of [Leah Neukirchen’s `fdate`](https://web.archive.org/web/0id_/leahneukirchen.org/dotfiles/bin/fdate) to fix #758. It provides only the time of day in local decimal time and skips the _Calendrier républicain_’s unwieldy – and unknowable[^1] – date system.

[^1]: We’re only [pretty sure](https://en.wikipedia.org/?curid=11396#Criticism_and_shortcomings) we know how leap years would have worked.