### PR TITLE
remove `stat`-dependent content

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,10 +14,6 @@
   branch = master
   path = custom/plugins/fast-syntax-highlighting
   url = https://github.com/zdharma-continuum/fast-syntax-highlighting
-[submodule "custom/plugins/samefile"]
-  branch = main
-  path = custom/plugins/samefile
-  url = https://github.com/LucasLarson/samefile
 [submodule "custom/plugins/git-default-branch"]
   branch = main
   path = custom/plugins/git-default-branch

--- a/.zshrc
+++ b/.zshrc
@@ -30,7 +30,7 @@ export HISTFILE SAVEHIST HISTSIZE
 export ZSH_COMPDUMP="${HOME%/}"'/.zcompdump'
 
 ## Plugins
-PLUGINS='gunstage:samefile:git-default-branch:zsh-abbr:zsh-diff-so-fancy:zsh-autosuggestions'"${PLUGINS:+:${PLUGINS-}}"
+PLUGINS='gunstage:git-default-branch:zsh-abbr:zsh-diff-so-fancy:zsh-autosuggestions'"${PLUGINS:+:${PLUGINS-}}"
 # plugin: fast-syntax-highlighting
 PLUGINS='fast-syntax-highlighting'"${PLUGINS:+:${PLUGINS-}}"
 # plugin: zsh-history-substring-search


### PR DESCRIPTION
`stat` is not a POSIX-defined utility: [this tool](https://github.com/LucasLarson/samefile) is not portable