### PR TITLE
remove ineffective `$HISTFILE` protection

### DIFF
--- a/.kshrc
+++ b/.kshrc
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-export HISTFILE="${HOME%/}"'/.ksh_history'


### PR DESCRIPTION
adding [`~/.kshrc`](https://github.com/LucasLarson/dotfiles/blob/12fb68b468/.kshrc) ([#686](https://github.com/LucasLarson/dotfiles/pull/686), [#687](https://github.com/LucasLarson/dotfiles/pull/687)) so that Korn shell may not pollute `$HISTFILE` does not work: upon launch as a non-login shell, Ksh already has access to `$HISTFILE`’s value and will append to it lines that choke[^2] Zsh.[^1] This request will fix #831, #686, #687.

---
[^1]: `$ pwd` in Zsh:
`: 1697044592:0;pwd`
[^2]: `$ pwd` in Ksh:
`: 1697044592:0;�pwd # which is printf ': 1697044592:0;\201\001pwd\n'`
