### PR TITLE
feat: add `sed`-remove-newlines abbreviation

### DIFF
--- a/.config/zsh-abbr/user-abbreviations
+++ b/.config/zsh-abbr/user-abbreviations
@@ -92,6 +92,9 @@ abbr --global prntf='printf'
 abbr --global prtinf='printf'
 abbr --global rpintf='printf'
 
+## sed
+abbr --global srn='command sed -n -e '\''H'\'' -e '\''$ {'\'' -e '\''x'\'' -e '\''s/\\n//gp'\'' -e '\''}'\'''
+
 ## soak
 abbr --global saok='soak'
 abbr --global 'c/saok'='cd -- "${HOME%/}"/c/soak'


### PR DESCRIPTION
this version of the `sed` command:
- [x] uses no exclamation point (`!`),[^1] obviating the need to modify `$LBUFFER`[^2]
- [x] escapes a newline (`\n` is saved here as `\\n`)[^3] so that when printed to the console, the newline recipe appears correctly as `\n`[^4] rather than as a mid-command linebreak[^5]

[^1]: `sed -e ':a' -e 'N' -e '$! b a' -e 's/\n//g'` performs the same task, but uses an exclamation point (`!`), which requires modifying `$LBUFFER`[^2]
[^2]: [olets/zsh-abbr #84](https://github.com/olets/zsh-abbr/issues/84#issuecomment-1475075037)
[^3]: `abbr -g "sed -n 'H;${x;s/\\n//gp;}'"`
[^4]: `         sed -n 'H;${x;s/\n//gp;}'`
[^5]: `         sed -n 'H;${x;s/⏎//gp;}' # such that ⏎ is a literal newline`