### PR TITLE
ci: skip Super-Linter’s Ansible, Checkov

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -55,6 +55,8 @@ jobs:
         uses: github/super-linter@v6
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ANSIBLE: false
+          VALIDATE_CHECKOV: false
           DEFAULT_BRANCH: main
           # Super-Linter requires this variable even if it is unset
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- [x] remove inapplicable Ansible validation from Super-Linter workflow
- [x] remove inapplicable Checkov validation from Super-Linter workflow