### PR TITLE
feat: indent `Makefile`s with tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Makefiles are properly indented using tabs
