### PR TITLE
refactor: use more readable empty-string tests

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -104,7 +104,7 @@ EDITOR="$(
     command -v -- vim ||
     command -v -- vi
 )"
-if test -n "${EDITOR-}"; then
+if test "${EDITOR-}" != ''; then
   export EDITOR
   alias e='command "${EDITOR:-vi}"'
   export VISUAL="${VISUAL:-${EDITOR:-vi}}"
@@ -210,7 +210,7 @@ set -o share_history
 set -o interactive_comments
 
 ## C, C++
-if test -n "$(command xcrun --show-sdk-path 2>/dev/null)"; then
+if test "$(command xcrun --show-sdk-path 2>/dev/null)" != ''; then
   CPATH="$(command xcrun --show-sdk-path)"'/usr/include'"${CPATH:+:${CPATH-}}"
   export CPATH
 fi
@@ -223,7 +223,7 @@ if test -d '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib'; then
 fi
 
 ## Go
-test -n "${GOPATH-}" &&
+test "${GOPATH-}" != '' &&
   test -d "${GOPATH-}"'/bin' &&
   PATH="${GOPATH-}"'/bin'"${PATH:+:${PATH-}}"
 
@@ -237,7 +237,7 @@ rbenv() {
 
 ## PATHs
 # prevent duplicate entries
-test -n "${ZSH-}" &&
+test "${ZSH-}" != '' &&
   export -U \
     PATH path \
     CDPATH cdpath \

--- a/custom/aliases.zsh
+++ b/custom/aliases.zsh
@@ -320,17 +320,17 @@ cleanup() {
     # delete crufty Zsh files
     # if `$ZSH_COMPDUMP` always generates a crufty file then skip
     # https://stackoverflow.com/a/8811800
-    if test -n "${ZSH_COMPDUMP-}" &&
+    if test "${ZSH_COMPDUMP-}" != '' &&
       test ! "${ZSH_COMPDUMP-}" != "${ZSH_COMPDUMP#*'zcompdump-'}" &&
       test ! "${ZSH_COMPDUMP-}" != "${ZSH_COMPDUMP#*'zcompdump.'}"; then
-      while test -n "$(
+      while test "$(
         command find -- "${HOME%/}" \
           -maxdepth 1 \
           -type f \
           ! -name "$(printf -- "*\n*")" \
           ! -name '.zcompdump' \
           -name '.zcompdump*'
-      )"; do
+      )" != ''; do
         command find -- "${HOME%/}" \
           -maxdepth 1 \
           -type f \
@@ -421,8 +421,8 @@ alias cp='cp -R'
 alias cpplint_r='command cpplint --counting=detailed --verbose=0 --filter=-legal/copyright --recursive -- .'
 
 cy() {
-  test -n "${DOTFILES-}" &&
-    test -n "${TEMPLATE-}" ||
+  test "${DOTFILES-}" != '' &&
+    test "${TEMPLATE-}" != '' ||
     return 1
 
   target="$(command git rev-parse --show-toplevel 2>/dev/null || command pwd -L)" ||
@@ -850,7 +850,7 @@ git_add() {
     shift
     ;;
   -o | --others | --untracked)
-    while test -n "$(command git ls-files --others --exclude-standard)"; do
+    while test "$(command git ls-files --others --exclude-standard)" != ''; do
       command git ls-files -z --others --exclude-standard |
         command xargs -0 git add --verbose 2>/dev/null
     done &&
@@ -949,7 +949,7 @@ alias gca='git_commit --amend'
 git_config_file_locations() {
   for scope in global system local worktree; do
     # do not return `.git/config` if called from outside a git repository
-    test -z "$(command git config --list --show-scope --"${scope-}" 2>/dev/null)" ||
+    test "$(command git config --list --show-scope --"${scope-}" 2>/dev/null)" = '' ||
       printf -- '%-10s%s\n' "${scope-}" "$(
         command git config --list --show-origin --"${scope-}" |
           command sed \
@@ -965,7 +965,7 @@ git_config_file_locations() {
 
 unalias -- 'gd' 2>/dev/null
 gd() {
-  if test -n "$(command git diff "$@" 2>/dev/null)"; then
+  if test "$(command git diff "$@" 2>/dev/null)" != ''; then
     command git diff "$@"
   else
     command git diff --cached "$@"
@@ -973,7 +973,7 @@ gd() {
 }
 unalias -- 'gds' 2>/dev/null
 gds() {
-  if test -n "$(command git diff --cached "$@" 2>/dev/null)"; then
+  if test "$(command git diff --cached "$@" 2>/dev/null)" != ''; then
     command git diff --cached "$@"
   else
     command git diff "$@"
@@ -1058,7 +1058,7 @@ git_commit_initial_commit() {
     fi
   command git commit --allow-empty --signoff --verbose --message="$(printf -- '\360\237\214\263\302\240 root commit')"
   # if there are non-repository files present, then add them and commit
-  if test -n "$(command git ls-files --others --exclude-standard)"; then
+  if test "$(command git ls-files --others --exclude-standard)" != ''; then
     command git add --verbose -- . &&
       command git commit --signoff --verbose --message="$(printf -- '\342\234\250\302\240 initial commit')"
   fi


### PR DESCRIPTION
replace:
- `test -n "${variable}"` with `test "${variable}" != ''`, and
- `test -z "${variable}"` with `test "${variable}" = ''`

https://github.com/anordal/shellharden/blob/35411af8d466fb8b75f9769c7bf4bcc0cb2a2920/how_to_do_things_safely_in_bash.md#are-empty-string-comparisons-any-special
