### PR TITLE
ci: skip `prettier` YAML validation 

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -57,6 +57,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_ANSIBLE: false
           VALIDATE_CHECKOV: false
+          VALIDATE_YAML_PRETTIER: false
           DEFAULT_BRANCH: main
           # Super-Linter requires this variable even if it is unset
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
contradicting YAML validation was already achieved at [`b6a4e8a4c0`](https://github.com/LucasLarson/dotfiles/commit/b6a4e8a4c01d9bc940831e6e0f51eba7e1cd6239)