### PR TITLE
fix: add missing image filename extensions (#967)

### DIFF
--- a/custom/aliases.sh
+++ b/custom/aliases.sh
@@ -2454,6 +2454,7 @@ find_image_files() {
     -name '*.[Ee][Pp][Ss]' -o \
     -name '*.[Ee][Xx][Rr]' -o \
     -name '*.[Ff][Ii][Gg]' -o \
+    -name '*.[Ff][Oo][Dd][Gg]' -o \
     -name '*.[Gg][Ii][Ff]' -o \
     -name '*.[Hh][Ee][Ii][Cc]' -o \
     -name '*.[Hh][Ee][Ii][Ff]' -o \
@@ -2474,6 +2475,7 @@ find_image_files() {
     -name '*.[Jj][Pp][Xx]' -o \
     -name '*.[Jj][Xx][Ll]' -o \
     -name '*.[Nn][Ee][Ff]' -o \
+    -name '*.[Oo][Dd][Gg]' -o \
     -name '*.[Oo][Rr][Ff]' -o \
     -name '*.[Pp][Bb][Mm]' -o \
     -name '*.[Pp][Gg][Mm]' -o \

--- a/custom/aliases.sh
+++ b/custom/aliases.sh
@@ -2474,6 +2474,8 @@ find_image_files() {
     -name '*.[Jj][Pp][Gg]' -o \
     -name '*.[Jj][Pp][Xx]' -o \
     -name '*.[Jj][Xx][Ll]' -o \
+    -name '*.[Kk][Rr][Aa]' -o \
+    -name '*.[Kk][Rr][Zz]' -o \
     -name '*.[Nn][Ee][Ff]' -o \
     -name '*.[Oo][Dd][Gg]' -o \
     -name '*.[Oo][Rr][Ff]' -o \

--- a/custom/aliases.sh
+++ b/custom/aliases.sh
@@ -2491,6 +2491,7 @@ find_image_files() {
     -name '*.[Pp][Pp][Mm]' -o \
     -name '*.[Pp][Ss][Dd]' -o \
     -name '*.[Pp][Xx][Mm]' -o \
+    -name '*.[Qq][Oo][Ii]' -o \
     -name '*.[Rr][Aa][Ww]' -o \
     -name '*.[Rr][Ii][Ff]johnalanwoods/maintained-modern-unix@c43c4b3f29/screenshots/zoxide.riff' -o \
     -name '*.[Rr][Ii][Ff]' -o \

--- a/custom/aliases.sh
+++ b/custom/aliases.sh
@@ -2440,6 +2440,7 @@ find_image_files() {
   command -p -- find -- . \
     '(' \
     -name '*.[Aa][Ii]' -o \
+    -name '*.[Aa][Pp][Nn][Gg]' -o \
     -name '*.[Aa][Rr][Ww]' -o \
     -name '*.[Aa][Vv][Ii][Ff]' -o \
     -name '*.[Bb][Mm][Pp]' -o \
@@ -2477,6 +2478,9 @@ find_image_files() {
     -name '*.[Pp][Bb][Mm]' -o \
     -name '*.[Pp][Gg][Mm]' -o \
     -name '*.[Pp][Ii][Cc]' -o \
+    -name '*.[Pp][Jj][Pp]' -o \
+    -name '*.[Pp][Jj][Pp][Ee][Gg]' -o \
+    -name '*.[Pp][Jj][Pp][Gg]' -o \
     -name '*.[Pp][Nn][Gg]' -o \
     -name '*.[Pp][Nn][Jj]' -o \
     -name '*.[Pp][Nn][Mm]' -o \
@@ -2490,6 +2494,7 @@ find_image_files() {
     -name '*.[Ss][Gg][Ii]' -o \
     -name '*.[Ss][Rr][Ww]' -o \
     -name '*.[Ss][Vv][Gg]' -o \
+    -name '*.[Ss][Vv][Gg][Zz]' -o \
     -name '*.[Tt][Gg][Aa]' -o \
     -name '*.[Tt][Hh][Mm]' -o \
     -name '*.[Tt][Ii][Ff]' -o \


### PR DESCRIPTION
add filename extensions to fix #967:
- [x] `.apng`
- [x] `.pjp`
- [x] `.pjpeg`
- [x] `.pjpg`
- [x] `.svgz`

add filename extensions to find OpenDocument graphics ([via](https://github.com/eza-community/eza/commit/fd30b5c572)):
- [x] `.odg`
- [x] `.fodg`

add filename extensions to find [Krita native-format](https://docs.krita.org/en/general_concepts/file_formats/file_kra.html) files ([via](https://github.com/eza-community/eza/commit/8d17115dee)):
- [x] `.kra`
- [x] `.krz`

add filename extension to find [Quite OK-format](https://qoiformat.org) files ([via](https://github.com/eza-community/eza/commit/29c7ca33d1)):
- [x] `.qoi`